### PR TITLE
RestaurantInfoDialogFragment 크래시 대응

### DIFF
--- a/app/src/main/java/com/wafflestudio/siksha2/ui/restaurantInfo/RestaurantInfoDialogFragment.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/restaurantInfo/RestaurantInfoDialogFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.BundleCompat
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.MapsInitializer
@@ -25,15 +26,11 @@ import java.util.*
 
 // TODO: 전반적으로 대충 짬 나중에 날잡고 고치기
 @AndroidEntryPoint
-class RestaurantInfoDialogFragment private constructor() :
-    BottomSheetDialogFragment(),
-    OnMapReadyCallback {
+class RestaurantInfoDialogFragment : BottomSheetDialogFragment(), OnMapReadyCallback {
 
     private lateinit var binding: FragmentRestaurantInfoBinding
     private val restaurantInfo: RestaurantInfo by lazy {
-        arguments?.getParcelable<RestaurantInfo>(
-            RESTAURANT_INFO
-        )!!
+        BundleCompat.getParcelable(requireArguments(), RESTAURANT_INFO, RestaurantInfo::class.java)!!
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/siksha-306012/crashlytics/app/android:com.wafflestudio.siksha2/issues/53aa5e6d7769dcbc89a77e35054fe7ba?hl=ko&time=last-seven-days&types=crash&versions=3.1.1%20(3010199)&sessionEventKey=65EAA710020B00017CEBA589C8EEEFD7_1922311432305320553

# 증상
RestaurantInfoDialogFragment(식당 상세 바텀시트)가 올라온 상태에서 화면을 돌리는 등 구성변경이 일어나면 크래시 발생

# 발생 이유
RestaurantInfoDialogFragment의 아무 파라미터도 없는 생성자가 private이었던 것이 문제.
프래그먼트가 구성 변경 등으로 인하여 파괴되었다가 다시 생성될 때, 프레임워크에서 아무 파라미터도 갖지 않는 생성자(empty primary constructor)를 호출한다.
그런데 RestaurantInfoDialogFragment처럼 프래그먼트의 constructor에 파라미터가 필요할 때가 있다. 그렇다고 primary constructor에 파라미터를 넣어버리면 기본으로 생성되는 empty primary constructor가 사라져, 프래그먼트가 다시 생성될 때 이런 예외가 발생한다.
따라서 주로 사용되는 것이 newInstance 패턴. 파라미터를 가지며 static한 팩토리 메서드를 만들어 프래그먼트 생성 시 사용한다. primary constructor를 건드리지 않았으므로 기본으로 생성되는 empty primary constructor가 남아있어 프래그먼트 재생성 시 아무 문제가 없다. 
한 가지 더 신경써야 하는 점은, newInstance()가 인자로 받은 값을 `argument`에 넣어줘야 한다는 것. 그래야 프래그먼트 재생성 시 이전 값이 복원된다.

# 결론
newInstance 패턴은 적용되어있었지만 empty primary constructor가 없어서 프래그먼트 재생성 시 크래시가 발생했다. primary constructor에서 private을 떼어 해결

참고:
https://black-jin0427.tistory.com/250
https://stackoverflow.com/questions/12062946/why-do-i-want-to-avoid-non-default-constructors-in-fragments

그리고 하는김에 getParcelable이 deprecate되어있던 것도 고쳤다