### PR TITLE
Firebase Remote Config IOException 대응

### DIFF
--- a/app/src/main/java/com/wafflestudio/siksha2/ui/SplashActivity.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/SplashActivity.kt
@@ -64,7 +64,20 @@ class SplashActivity : AppCompatActivity() {
                 return@launch
             }
 
-            featureChecker.fetchFeaturesConfig()
+            runCatching {
+                featureChecker.fetchFeaturesConfig()
+            }.onFailure {
+                when (it) {
+                    is IOException -> {
+                        showToast("네트워크 연결이 불안정합니다.")
+                        delay(1000L)
+                        startActivity(Intent(this@SplashActivity, RootActivity::class.java))
+                        finish()
+                        return@launch
+                    }
+                    else -> throw it
+                }
+            }
 
             if (checkLoginStatus().not()) {
                 binding.googleLoginButton.setVisibleOrGone(true)


### PR DESCRIPTION
- 대응했다고 생각했는데 터진다....
  - FirebaseInstallationException도 발생하고있는데, 그건 google-services.json이 잘못 들어간 것 때문인 것 같다. 아래 IOException들도 그거랑 관련있는진 모르겠는데... 일단 IOException만 대응하고, google-services.json도 고쳐서 다시 배포 예정
  - https://console.firebase.google.com/u/0/project/siksha-306012/crashlytics/app/android:com.wafflestudio.siksha2/issues/3ac709fee4e9bac7ed5276533f6618a4?versions=3.1.2%20(3010299)&time=last-seven-days&types=crash&sessionEventKey=66029CAF03720001374EF088F1A03E3B_1929055452610566759
  - https://console.firebase.google.com/u/0/project/siksha-306012/crashlytics/app/android:com.wafflestudio.siksha2/issues/3ac709fee4e9bac7ed5276533f6618a4?versions=3.1.2%20(3010299)&time=last-seven-days&types=crash&sessionEventKey=66029CAF03720001374EF088F1A03E3B_1929055452610566759
  - https://console.firebase.google.com/u/0/project/siksha-306012/crashlytics/app/android:com.wafflestudio.siksha2/issues/d2869efae8bac84497c91fdd11228223?versions=3.1.2%20(3010299)&time=last-seven-days&types=crash&sessionEventKey=6602920E022900014E34D297C4566F22_1929043740602998194