### PR TITLE
DialogFragment 구성 변경 시 크래시 대응

### DIFF
--- a/app/src/main/java/com/wafflestudio/siksha2/ui/SikshaDialog.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/SikshaDialog.kt
@@ -12,12 +12,13 @@ import androidx.fragment.app.DialogFragment
 import com.wafflestudio.siksha2.databinding.DialogDefaultBinding
 
 // TODO: 전반적으로 대충 짬 나중에 날잡고 고치기
-class SikshaDialog(private val message: CharSequence) : DialogFragment() {
+class SikshaDialog : DialogFragment() {
     private lateinit var binding: DialogDefaultBinding
 
     private var listener: SikshaDialogListener? = null
+    private val message by lazy { arguments?.getCharSequence(ARG_MESSAGE) }
 
-    fun setListener(listener: SikshaDialogListener) {
+    fun setListener(listener: SikshaDialogListener) { // TODO: 구성 변경 후에도 listener 유지되도록 고치기
         this.listener = listener
     }
 
@@ -48,6 +49,18 @@ class SikshaDialog(private val message: CharSequence) : DialogFragment() {
         binding.content.text = message
         binding.positive.setOnClickListener { listener?.onPositive() }
         binding.negative.setOnClickListener { listener?.onNegative() }
+    }
+
+    companion object {
+        private const val ARG_MESSAGE = "message"
+
+        @JvmStatic
+        fun newInstance(message: CharSequence) =
+            SikshaDialog().apply {
+                arguments = Bundle().apply {
+                    putCharSequence(ARG_MESSAGE, message)
+                }
+            }
     }
 }
 

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/SettingFragment.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/SettingFragment.kt
@@ -94,7 +94,7 @@ class SettingFragment : Fragment() {
 
         binding.logoutRow.setOnClickListener {
             // TODO: SikshaDialogController 만들기
-            val dialog = SikshaDialog("정말로 로그아웃 하시겠습니까?")
+            val dialog = SikshaDialog.newInstance("정말로 로그아웃 하시겠습니까?")
             dialog.setListener(
                 object : SikshaDialogListener {
                     override fun onPositive() {

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/info/SikshaInfoFragment.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/info/SikshaInfoFragment.kt
@@ -60,7 +60,7 @@ class SikshaInfoFragment : Fragment() {
 
         binding.withdrawalText.setOnClickListener {
             // TODO: SikshaDialogController 만들기
-            val dialog = SikshaDialog("앱 계정을 삭제합니다.\n이 계정으로 등록된 리뷰 정보들도 모두 함께 삭제됩니다.")
+            val dialog = SikshaDialog.newInstance("앱 계정을 삭제합니다.\n이 계정으로 등록된 리뷰 정보들도 모두 함께 삭제됩니다.")
             dialog.setListener(
                 object : SikshaDialogListener {
                     override fun onPositive() {

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/menuDetail/MenuDetailFragment.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/menuDetail/MenuDetailFragment.kt
@@ -143,7 +143,7 @@ class MenuDetailFragment : Fragment() {
             for (i in 0 until 2) {
                 if (i < imageUrlList.size) {
                     imageReviewList[i].setOnClickListener {
-                        val dialog = ReviewImageDialog(imageUrlList[i])
+                        val dialog = ReviewImageDialog.newInstance(imageUrlList[i])
                         dialog.show(childFragmentManager, "review_image_${imageUrlList[i]}")
                     }
                 }

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/menuDetail/MenuReviewsAdapter.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/menuDetail/MenuReviewsAdapter.kt
@@ -36,7 +36,7 @@ class MenuReviewsAdapter constructor(
                                     setImage(it[i])
                                     fragmentManager?.let {
                                         setImageClickListener { url ->
-                                            val dialog = ReviewImageDialog(url)
+                                            val dialog = ReviewImageDialog.newInstance(url)
                                             dialog.show(fragmentManager, "review_image_$url")
                                         }
                                     }

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/menuDetail/ReviewImageDialog.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/menuDetail/ReviewImageDialog.kt
@@ -10,8 +10,10 @@ import androidx.fragment.app.DialogFragment
 import com.wafflestudio.siksha2.databinding.DialogReviewImageBinding
 import com.wafflestudio.siksha2.utils.setImageUrl
 
-class ReviewImageDialog(private val url: String) : DialogFragment() {
+class ReviewImageDialog : DialogFragment() {
+
     private lateinit var binding: DialogReviewImageBinding
+    private val url by lazy { arguments?.getString(ARG_URL)!! }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -30,5 +32,17 @@ class ReviewImageDialog(private val url: String) : DialogFragment() {
         binding.closeButton.setOnClickListener {
             dismiss()
         }
+    }
+
+    companion object {
+        private const val ARG_URL = "url"
+
+        @JvmStatic
+        fun newInstance(url: String) =
+            ReviewImageDialog().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_URL, url)
+                }
+            }
     }
 }

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/restaurantInfo/RestaurantInfoDialogFragment.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/restaurantInfo/RestaurantInfoDialogFragment.kt
@@ -30,7 +30,7 @@ class RestaurantInfoDialogFragment : BottomSheetDialogFragment(), OnMapReadyCall
 
     private lateinit var binding: FragmentRestaurantInfoBinding
     private val restaurantInfo: RestaurantInfo by lazy {
-        BundleCompat.getParcelable(requireArguments(), RESTAURANT_INFO, RestaurantInfo::class.java)!!
+        BundleCompat.getParcelable(requireArguments(), ARG_RESTAURANT_INFO, RestaurantInfo::class.java)!!
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -231,7 +231,7 @@ class RestaurantInfoDialogFragment : BottomSheetDialogFragment(), OnMapReadyCall
     }
 
     companion object {
-        const val RESTAURANT_INFO = "restaurant_info"
+        private const val ARG_RESTAURANT_INFO = "restaurant_info"
 
         private const val BREAKFAST_TIME_AS_MINUTE = 510
         private const val LUNCH_TIME_AS_MINUTE = 750
@@ -241,7 +241,7 @@ class RestaurantInfoDialogFragment : BottomSheetDialogFragment(), OnMapReadyCall
         fun newInstance(restaurantInfo: RestaurantInfo) =
             RestaurantInfoDialogFragment().apply {
                 arguments = Bundle().apply {
-                    putParcelable(RESTAURANT_INFO, restaurantInfo)
+                    putParcelable(ARG_RESTAURANT_INFO, restaurantInfo)
                 }
             }
     }


### PR DESCRIPTION
#58 에서 RestaurantInfoDialogFragment의 크래시를 고친 것과 동일. DialogFragment를 상속받는 다른 다이얼로그에도 적용했다
SikshaDialog의 경우 구성 변경 시 SikshaDialogListener가 날아가서 클릭이 되지 않는다... 정말 날 잡고 고쳐야할듯