### PR TITLE
이미지 압축 유틸함수 생성

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -170,9 +170,6 @@ dependencies {
     // Glide
     implementation("com.github.bumptech.glide:glide:4.15.1")
 
-    // Image Compression
-    implementation("id.zelory:compressor:3.0.1")
-
     testImplementation("junit:junit:4.+")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/menuDetail/MenuDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/menuDetail/MenuDetailViewModel.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.siksha2.ui.menuDetail
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -11,19 +10,14 @@ import androidx.paging.PagingData
 import com.wafflestudio.siksha2.models.Menu
 import com.wafflestudio.siksha2.models.Review
 import com.wafflestudio.siksha2.repositories.MenuRepository
-import com.wafflestudio.siksha2.utils.PathUtil
+import com.wafflestudio.siksha2.utils.ImageUtil
 import com.wafflestudio.siksha2.utils.showToast
 import dagger.hilt.android.lifecycle.HiltViewModel
-import id.zelory.compressor.Compressor
-import id.zelory.compressor.constraint.format
-import id.zelory.compressor.constraint.resolution
-import id.zelory.compressor.constraint.size
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
-import java.io.File
 import java.io.IOException
 import javax.inject.Inject
 
@@ -167,7 +161,10 @@ class MenuDetailViewModel @Inject constructor(
             context.showToast("이미지 압축 중입니다.")
             _leaveReviewState.value = ReviewState.COMPRESSING
             val imageList = _imageUriList.value?.map {
-                getCompressedImage(context, it)
+                ImageUtil.getCompressedImage(context, it)
+            }?.map { file ->
+                val requestBody = file.asRequestBody("image/jpeg".toMediaTypeOrNull())
+                MultipartBody.Part.createFormData("images", file.name, requestBody)
             }
             val commentBody = MultipartBody.Part.createFormData("comment", comment)
             imageList?.let {
@@ -176,18 +173,6 @@ class MenuDetailViewModel @Inject constructor(
         } else {
             menuRepository.leaveMenuReview(menuId, score, comment)
         }
-    }
-
-    private suspend fun getCompressedImage(context: Context, uri: Uri): MultipartBody.Part {
-        val path = PathUtil.getPath(context, uri)
-        var file = File(path)
-        file = Compressor.compress(context, file) {
-            resolution(300, 300)
-            size(100000)
-            format(Bitmap.CompressFormat.JPEG)
-        }
-        val requestBody = file.asRequestBody("image/jpeg".toMediaTypeOrNull())
-        return MultipartBody.Part.createFormData("images", file.name, requestBody)
     }
 
     enum class State {

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/ImageUtil.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/ImageUtil.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.siksha2.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import com.wafflestudio.siksha2.utils.compressor.Compressor
+import com.wafflestudio.siksha2.utils.compressor.format
+import com.wafflestudio.siksha2.utils.compressor.resolution
+import com.wafflestudio.siksha2.utils.compressor.size
+import java.io.File
+
+object ImageUtil {
+    suspend fun getCompressedImage(context: Context, imageUri: Uri): File {
+        return Compressor.compress(context, imageUri) {
+            resolution(300, 300)
+            size(100000)
+            format(Bitmap.CompressFormat.JPEG)
+        }
+    }
+}

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/Compression.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/Compression.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.siksha2.utils.compressor
+
+class Compression {
+    internal val constraints: MutableList<Constraint> = mutableListOf()
+
+    fun constraint(constraint: Constraint) {
+        constraints.add(constraint)
+    }
+}

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/Compressor.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/Compressor.kt
@@ -1,0 +1,31 @@
+package com.wafflestudio.siksha2.utils.compressor
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Created on : January 22, 2020
+ * Author     : zetbaitsu
+ * Name       : Zetra
+ * GitHub     : https://github.com/zetbaitsu
+ */
+object Compressor {
+    suspend fun compress(
+        context: Context,
+        imageFile: File,
+        coroutineContext: CoroutineContext = Dispatchers.IO,
+        compressionPatch: Compression.() -> Unit = { default() }
+    ) = withContext(coroutineContext) {
+        val compression = Compression().apply(compressionPatch)
+        var result = copyToCache(context, imageFile)
+        compression.constraints.forEach { constraint ->
+            while (constraint.isSatisfied(result).not()) {
+                result = constraint.satisfy(result)
+            }
+        }
+        return@withContext result
+    }
+}

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/Compressor.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/Compressor.kt
@@ -1,9 +1,9 @@
 package com.wafflestudio.siksha2.utils.compressor
 
 import android.content.Context
+import android.net.Uri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.File
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -15,12 +15,12 @@ import kotlin.coroutines.CoroutineContext
 object Compressor {
     suspend fun compress(
         context: Context,
-        imageFile: File,
+        imageUri: Uri,
         coroutineContext: CoroutineContext = Dispatchers.IO,
         compressionPatch: Compression.() -> Unit = { default() }
     ) = withContext(coroutineContext) {
         val compression = Compression().apply(compressionPatch)
-        var result = copyToCache(context, imageFile)
+        var result = copyToCache(context, imageUri)
         compression.constraints.forEach { constraint ->
             while (constraint.isSatisfied(result).not()) {
                 result = constraint.satisfy(result)

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/CompressorUtil.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/CompressorUtil.kt
@@ -1,0 +1,108 @@
+package com.wafflestudio.siksha2.utils.compressor
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Created on : January 24, 2020
+ * Author     : zetbaitsu
+ * Name       : Zetra
+ * GitHub     : https://github.com/zetbaitsu
+ */
+private val separator = File.separator
+
+private fun cachePath(context: Context) = "${context.cacheDir.path}${separator}compressor$separator"
+
+fun File.compressFormat() = when (extension.toLowerCase()) {
+    "png" -> Bitmap.CompressFormat.PNG
+    "webp" -> Bitmap.CompressFormat.WEBP
+    else -> Bitmap.CompressFormat.JPEG
+}
+
+fun Bitmap.CompressFormat.extension() = when (this) {
+    Bitmap.CompressFormat.PNG -> "png"
+    Bitmap.CompressFormat.WEBP -> "webp"
+    else -> "jpg"
+}
+
+fun loadBitmap(imageFile: File) = BitmapFactory.decodeFile(imageFile.absolutePath).run {
+    determineImageRotation(imageFile, this)
+}
+
+fun decodeSampledBitmapFromFile(imageFile: File, reqWidth: Int, reqHeight: Int): Bitmap {
+    return BitmapFactory.Options().run {
+        inJustDecodeBounds = true
+        BitmapFactory.decodeFile(imageFile.absolutePath, this)
+
+        inSampleSize = calculateInSampleSize(this, reqWidth, reqHeight)
+
+        inJustDecodeBounds = false
+        BitmapFactory.decodeFile(imageFile.absolutePath, this)
+    }
+}
+
+fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
+    // Raw height and width of image
+    val (height: Int, width: Int) = options.run { outHeight to outWidth }
+    var inSampleSize = 1
+
+    if (height > reqHeight || width > reqWidth) {
+
+        val halfHeight: Int = height / 2
+        val halfWidth: Int = width / 2
+
+        // Calculate the largest inSampleSize value that is a power of 2 and keeps both
+        // height and width larger than the requested height and width.
+        while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+            inSampleSize *= 2
+        }
+    }
+
+    return inSampleSize
+}
+
+fun determineImageRotation(imageFile: File, bitmap: Bitmap): Bitmap {
+    val exif = ExifInterface(imageFile.absolutePath)
+    val orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0)
+    val matrix = Matrix()
+    when (orientation) {
+        6 -> matrix.postRotate(90f)
+        3 -> matrix.postRotate(180f)
+        8 -> matrix.postRotate(270f)
+    }
+    return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+}
+
+internal fun copyToCache(context: Context, imageFile: File): File {
+    return imageFile.copyTo(File("${cachePath(context)}${imageFile.name}"), true)
+}
+
+fun overWrite(imageFile: File, bitmap: Bitmap, format: Bitmap.CompressFormat = imageFile.compressFormat(), quality: Int = 100): File {
+    val result = if (format == imageFile.compressFormat()) {
+        imageFile
+    } else {
+        File("${imageFile.absolutePath.substringBeforeLast(".")}.${format.extension()}")
+    }
+    imageFile.delete()
+    saveBitmap(bitmap, result, format, quality)
+    return result
+}
+
+fun saveBitmap(bitmap: Bitmap, destination: File, format: Bitmap.CompressFormat = destination.compressFormat(), quality: Int = 100) {
+    destination.parentFile?.mkdirs()
+    var fileOutputStream: FileOutputStream? = null
+    try {
+        fileOutputStream = FileOutputStream(destination.absolutePath)
+        bitmap.compress(format, quality, fileOutputStream)
+    } finally {
+        fileOutputStream?.run {
+            flush()
+            close()
+        }
+    }
+}

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/CompressorUtil.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/CompressorUtil.kt
@@ -57,7 +57,6 @@ fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeig
     var inSampleSize = 1
 
     if (height > reqHeight || width > reqWidth) {
-
         val halfHeight: Int = height / 2
         val halfWidth: Int = width / 2
 
@@ -109,9 +108,13 @@ fun copyToCache(context: Context, srcFileUri: Uri): File {
 fun getFileName(context: Context, uri: Uri): String {
     val resolver = context.contentResolver
     val cursor = resolver.query(
-        uri, arrayOf(
+        uri,
+        arrayOf(
             OpenableColumns.DISPLAY_NAME
-        ), null, null, null
+        ),
+        null,
+        null,
+        null
     )
     cursor.use {
         val nameIndex = it!!.getColumnIndex(OpenableColumns.DISPLAY_NAME)

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/CompressorUtil.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/CompressorUtil.kt
@@ -5,8 +5,13 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.media.ExifInterface
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.provider.OpenableColumns
 import java.io.File
 import java.io.FileOutputStream
+import java.text.SimpleDateFormat
+import java.util.*
 
 /**
  * Created on : January 24, 2020
@@ -80,6 +85,58 @@ fun determineImageRotation(imageFile: File, bitmap: Bitmap): Bitmap {
 
 internal fun copyToCache(context: Context, imageFile: File): File {
     return imageFile.copyTo(File("${cachePath(context)}${imageFile.name}"), true)
+}
+
+fun copyToCache(context: Context, srcFileUri: Uri): File {
+    val cacheFile = File("${cachePath(context)}${getFileName(context, srcFileUri)}")
+    cacheFile.parentFile.mkdirs()
+    if (cacheFile.exists()) {
+        cacheFile.delete()
+    }
+    cacheFile.createNewFile()
+    cacheFile.deleteOnExit()
+    val fd = context.contentResolver.openFileDescriptor(srcFileUri, "r")
+    val inputStream = ParcelFileDescriptor.AutoCloseInputStream(fd)
+    val outputStream = FileOutputStream(cacheFile)
+    inputStream.use {
+        outputStream.use {
+            inputStream.copyTo(outputStream)
+        }
+    }
+    return cacheFile
+}
+
+fun getFileName(context: Context, uri: Uri): String {
+    val resolver = context.contentResolver
+    val cursor = resolver.query(
+        uri, arrayOf(
+            OpenableColumns.DISPLAY_NAME
+        ), null, null, null
+    )
+    cursor.use {
+        val nameIndex = it!!.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+        if (it.moveToFirst()) {
+            return it.getString(nameIndex)
+        } else {
+            val prefix = "IMG_" + SimpleDateFormat(
+                "yyyyMMdd_",
+                Locale.getDefault()
+            ).format(Date()) + System.nanoTime()
+            return when (val fileMimeType = resolver.getType(uri)) {
+                "image/jpg", "image/jpeg" -> {
+                    "$prefix.jpeg"
+                }
+
+                "image/png" -> {
+                    "$prefix.png"
+                }
+
+                else -> {
+                    throw IllegalStateException("$fileMimeType fallback display name not supported")
+                }
+            }
+        }
+    }
 }
 
 fun overWrite(imageFile: File, bitmap: Bitmap, format: Bitmap.CompressFormat = imageFile.compressFormat(), quality: Int = 100): File {

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/Constraint.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/Constraint.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.siksha2.utils.compressor
+
+import java.io.File
+
+interface Constraint {
+    fun isSatisfied(imageFile: File): Boolean
+
+    fun satisfy(imageFile: File): File
+}

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/DefaultConstraint.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/DefaultConstraint.kt
@@ -1,0 +1,42 @@
+package com.wafflestudio.siksha2.utils.compressor
+
+import android.graphics.Bitmap
+import java.io.File
+
+/**
+ * Created on : January 25, 2020
+ * Author     : zetbaitsu
+ * Name       : Zetra
+ * GitHub     : https://github.com/zetbaitsu
+ */
+class DefaultConstraint(
+    private val width: Int = 612,
+    private val height: Int = 816,
+    private val format: Bitmap.CompressFormat = Bitmap.CompressFormat.JPEG,
+    private val quality: Int = 80
+) : Constraint {
+    private var isResolved = false
+
+    override fun isSatisfied(imageFile: File): Boolean {
+        return isResolved
+    }
+
+    override fun satisfy(imageFile: File): File {
+        val result = decodeSampledBitmapFromFile(imageFile, width, height).run {
+            determineImageRotation(imageFile, this).run {
+                overWrite(imageFile, this, format, quality)
+            }
+        }
+        isResolved = true
+        return result
+    }
+}
+
+fun Compression.default(
+    width: Int = 612,
+    height: Int = 816,
+    format: Bitmap.CompressFormat = Bitmap.CompressFormat.JPEG,
+    quality: Int = 80
+) {
+    constraint(DefaultConstraint(width, height, format, quality))
+}

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/FormatConstraint.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/FormatConstraint.kt
@@ -1,0 +1,25 @@
+package com.wafflestudio.siksha2.utils.compressor
+
+import android.graphics.Bitmap
+import java.io.File
+
+/**
+ * Created on : January 24, 2020
+ * Author     : zetbaitsu
+ * Name       : Zetra
+ * GitHub     : https://github.com/zetbaitsu
+ */
+class FormatConstraint(private val format: Bitmap.CompressFormat) : Constraint {
+
+    override fun isSatisfied(imageFile: File): Boolean {
+        return format == imageFile.compressFormat()
+    }
+
+    override fun satisfy(imageFile: File): File {
+        return overWrite(imageFile, loadBitmap(imageFile), format)
+    }
+}
+
+fun Compression.format(format: Bitmap.CompressFormat) {
+    constraint(FormatConstraint(format))
+}

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/ResolutionConstraint.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/ResolutionConstraint.kt
@@ -1,0 +1,33 @@
+package com.wafflestudio.siksha2.utils.compressor
+
+import android.graphics.BitmapFactory
+import java.io.File
+
+/**
+ * Created on : January 24, 2020
+ * Author     : zetbaitsu
+ * Name       : Zetra
+ * GitHub     : https://github.com/zetbaitsu
+ */
+class ResolutionConstraint(private val width: Int, private val height: Int) : Constraint {
+
+    override fun isSatisfied(imageFile: File): Boolean {
+        return BitmapFactory.Options().run {
+            inJustDecodeBounds = true
+            BitmapFactory.decodeFile(imageFile.absolutePath, this)
+            calculateInSampleSize(this, width, height) <= 1
+        }
+    }
+
+    override fun satisfy(imageFile: File): File {
+        return decodeSampledBitmapFromFile(imageFile, width, height).run {
+            determineImageRotation(imageFile, this).run {
+                overWrite(imageFile, this)
+            }
+        }
+    }
+}
+
+fun Compression.resolution(width: Int, height: Int) {
+    constraint(ResolutionConstraint(width, height))
+}

--- a/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/SizeConstraint.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/utils/compressor/SizeConstraint.kt
@@ -1,0 +1,32 @@
+package com.wafflestudio.siksha2.utils.compressor
+
+import java.io.File
+
+/**
+ * Created on : January 24, 2020
+ * Author     : zetbaitsu
+ * Name       : Zetra
+ * GitHub     : https://github.com/zetbaitsu
+ */
+class SizeConstraint(
+    private val maxFileSize: Long,
+    private val stepSize: Int = 10,
+    private val maxIteration: Int = 10,
+    private val minQuality: Int = 10
+) : Constraint {
+    private var iteration: Int = 0
+
+    override fun isSatisfied(imageFile: File): Boolean {
+        return imageFile.length() <= maxFileSize || iteration >= maxIteration
+    }
+
+    override fun satisfy(imageFile: File): File {
+        iteration++
+        val quality = (100 - iteration * stepSize).takeIf { it >= minQuality } ?: minQuality
+        return overWrite(imageFile, loadBitmap(imageFile), quality = quality)
+    }
+}
+
+fun Compression.size(maxFileSize: Long, stepSize: Int = 10, maxIteration: Int = 10) {
+    constraint(SizeConstraint(maxFileSize, stepSize, maxIteration))
+}


### PR DESCRIPTION
# 변경점
- Zelory Compressor 베껴와서, 압축 대상 이미지를 File 대신 Uri로 받도록 수정
  - Zelory Compressor 의존성은 제거
  - 나중에 utils/compressor 통째로 모듈로 분리하면 좋을듯? 커뮤니티끝나고 여유생기면 하기
- ImageUtil.getCompressedImage() 생성
  - 사이즈 300x300, 최대 크기 100KB(기존 스펙)
- MenuDetailViewModel에 우선 적용해둠