### PR TITLE
이미지뷰어 문자열 포맷 수정

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,5 +76,5 @@
     <string name="community_comment_hint">댓글을 입력하세요.</string>
     <string name="community_comment_anonymous">익명</string>
     <string name="siksha_info_dialog_withdrawal_content">앱 계정을 삭제합니다.\n이 계정으로 등록된 리뷰 정보들도 모두 함께 삭제됩니다.</string>
-    <string name="image_viewer_current_page">%d/%d</string>
+    <string name="image_viewer_current_page">%1$d/%2$d</string>
 </resources>


### PR DESCRIPTION
## 문제
CI 돌 때 assembleStagingDebug에서 이런 에러가 나면서 터졌다([링크](https://github.com/wafflestudio/siksha-android/actions/runs/10491467574/job/29060693641#step:10:355))
```
/home/runner/.gradle/caches/transforms-3/1454b6bca49536261d290802f8f4cc75/transformed/jetified-ui-release/res/values/values.xml:45:4: Multiple substitutions specified in non-positional format of string resource string/image_viewer_current_page. Did you mean to add the formatted="false" attribute?
```
image_viewer_current_page 문자열 리소스에 문제가 있었다

## 해결
`%1$d/%2$d`로 포맷을 똑바로 고쳤다