### PR TITLE
게시글 상세 페이지 탑바에 게시판이 잘못 표시되는 버그 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/siksha2/compose/ui/community/PostDetailScreen.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/compose/ui/community/PostDetailScreen.kt
@@ -90,7 +90,7 @@ fun PostDetailRoute(
     postDetailViewModel: PostDetailViewModel = hiltViewModel()
 ) {
     val post by postDetailViewModel.post.collectAsState()
-    val board by postListViewModel.selectedBoard.collectAsState()
+    val board by postDetailViewModel.board.collectAsState()
     val comments = postDetailViewModel.commentPagingData.collectAsLazyPagingItems()
     val isAnonymous by postDetailViewModel.isAnonymous.collectAsState()
 

--- a/app/src/main/java/com/wafflestudio/siksha2/network/SikshaApi.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/network/SikshaApi.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.siksha2.network
 
 import com.wafflestudio.siksha2.models.Menu
 import com.wafflestudio.siksha2.network.dto.*
-import com.wafflestudio.siksha2.network.dto.core.BoardDto
 import okhttp3.MultipartBody
 import retrofit2.http.*
 import java.time.LocalDate

--- a/app/src/main/java/com/wafflestudio/siksha2/network/SikshaApi.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/network/SikshaApi.kt
@@ -99,6 +99,11 @@ interface SikshaApi {
     @GET("/community/boards")
     suspend fun getBoards(): GetBoardsResult
 
+    @GET("/community/boards/{board_id}")
+    suspend fun getBoard(
+        @Path("board_id") boardId: Long
+    ): GetBoardResult
+
     @GET("/community/posts")
     suspend fun getPosts(
         @Query("board_id") boardId: Long,

--- a/app/src/main/java/com/wafflestudio/siksha2/network/dto/GetBoardResult.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/network/dto/GetBoardResult.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.siksha2.network.dto
+
+import com.wafflestudio.siksha2.network.dto.core.BoardDto
+
+typealias GetBoardResult = BoardDto

--- a/app/src/main/java/com/wafflestudio/siksha2/repositories/CommunityRepository.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/repositories/CommunityRepository.kt
@@ -24,6 +24,10 @@ class CommunityRepository @Inject constructor(
         return api.getBoards().map { it.toBoard() }
     }
 
+    suspend fun getBoard(boardId: Long): Board {
+        return api.getBoard(boardId).toBoard()
+    }
+
     fun getUserPostPagingSource() = UserPostPagingSource(api)
     fun getPostPagingSource(boardId: Long) = PostPagingSource(boardId, api)
 

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/main/community/PostDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/main/community/PostDetailViewModel.kt
@@ -7,6 +7,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.wafflestudio.siksha2.models.Board
 import com.wafflestudio.siksha2.models.Comment
 import com.wafflestudio.siksha2.models.Post
 import com.wafflestudio.siksha2.repositories.CommunityRepository
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -31,6 +33,10 @@ class PostDetailViewModel @Inject constructor(
 
     private val _post = MutableStateFlow<Post>(Post())
     val post: StateFlow<Post> = _post
+
+    val board = post.map {
+        communityRepository.getBoard(it.boardId)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, Board.Empty)
 
     val commentPagingData = Pager(
         config = PagingConfig(

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/main/community/PostDetailViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/main/community/PostDetailViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -34,9 +33,8 @@ class PostDetailViewModel @Inject constructor(
     private val _post = MutableStateFlow<Post>(Post())
     val post: StateFlow<Post> = _post
 
-    val board = post.map {
-        communityRepository.getBoard(it.boardId)
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, Board.Empty)
+    private val _board = MutableStateFlow<Board>(Board.Empty)
+    val board: StateFlow<Board> = _board
 
     val commentPagingData = Pager(
         config = PagingConfig(
@@ -65,6 +63,7 @@ class PostDetailViewModel @Inject constructor(
     private fun refreshPost(postId: Long) {
         viewModelScope.launch {
             _post.value = communityRepository.getPost(postId)
+            _board.value = communityRepository.getBoard(post.value.boardId)
         }
     }
 


### PR DESCRIPTION
- 게시글 상세 페이지 진입 -> GET /community/boards/{board_id} 찔러서 게시판 받아오고 -> 탑바에 표시하도록 수정했다