### PR TITLE
중복 신고 시 토스트 문구 구분

### DIFF
--- a/app/src/main/java/com/wafflestudio/siksha2/compose/ui/community/CommentReportScreen.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/compose/ui/community/CommentReportScreen.kt
@@ -51,7 +51,7 @@ fun CommentReportRoute(
                 }
 
                 is CommentReportEvent.ReportCommentFailed -> {
-                    context.showToast("신고가 실패했습니다.")
+                    context.showToast(it.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/wafflestudio/siksha2/compose/ui/community/PostReportScreen.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/compose/ui/community/PostReportScreen.kt
@@ -51,7 +51,7 @@ fun PostReportRoute(
                 }
 
                 is PostReportEvent.ReportPostFailed -> {
-                    context.showToast("신고가 실패했습니다.")
+                    context.showToast(it.errorMessage)
                 }
             }
         }


### PR DESCRIPTION
- 유저가 이미 신고해놓고 까먹어서 다시 신고했을 때, 무지성 오류 띄우면 버그로 오해받을테니 문구를 구분했다
- 나중에 꼭 에러핸들링 CallAdapter 만들어서 서버에서 내려주는 에러메시지 그대로 보여주자........