### PR TITLE
최신버전 체크 로직 수정

### DIFF
--- a/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/SettingFragment.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/SettingFragment.kt
@@ -50,8 +50,8 @@ class SettingFragment : Fragment() {
             }
         }
 
-        vm.versionCheck.observe(viewLifecycleOwner) { isLatestVersion ->
-            binding.versionCheckText.text = if (isLatestVersion) {
+        vm.isLatestAppVersion.observe(viewLifecycleOwner) { isLatestAppVersion ->
+            binding.versionCheckText.text = if (isLatestAppVersion) {
                 getString(R.string.setting_using_latest_version)
             } else {
                 getString(R.string.setting_need_update)

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/SettingFragment.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/SettingFragment.kt
@@ -50,10 +50,12 @@ class SettingFragment : Fragment() {
             }
         }
 
-        if (vm.versionCheck.value == true) {
-            binding.versionCheckText.text = getString(R.string.setting_using_latest_version)
-        } else {
-            binding.versionCheckText.text = getString(R.string.setting_need_update)
+        vm.versionCheck.observe(viewLifecycleOwner) { isLatestVersion ->
+            binding.versionCheckText.text = if (isLatestVersion) {
+                getString(R.string.setting_using_latest_version)
+            } else {
+                getString(R.string.setting_need_update)
+            }
         }
 
         binding.infoRow.setOnClickListener {

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/SettingViewModel.kt
@@ -31,8 +31,8 @@ class SettingViewModel @Inject constructor(
     private val _userData = MutableLiveData<User>()
     val userData: LiveData<User> get() = _userData
 
-    private val _versionCheck = MutableLiveData<Boolean>()
-    val versionCheck: LiveData<Boolean> get() = _versionCheck
+    private val _isLatestAppVersion = MutableLiveData<Boolean>()
+    val isLatestAppVersion: LiveData<Boolean> get() = _isLatestAppVersion
 
     val packageVersion: String = BuildConfig.VERSION_NAME
 
@@ -55,7 +55,7 @@ class SettingViewModel @Inject constructor(
 
     private suspend fun checkAppVersion() {
         val latestVersionNum = userStatusManager.getVersion()
-        _versionCheck.value = (packageVersion == latestVersionNum)
+        _isLatestAppVersion.value = (packageVersion == latestVersionNum)
     }
 
     val showEmptyRestaurantFlow = restaurantRepository.showEmptyRestaurant.asFlow()

--- a/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/account/UserAccountFragment.kt
+++ b/app/src/main/java/com/wafflestudio/siksha2/ui/main/setting/account/UserAccountFragment.kt
@@ -39,7 +39,7 @@ class UserAccountFragment : Fragment(), DefaultDialogListener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        if (vm.versionCheck.value == true) {
+        if (vm.isLatestAppVersion.value == true) {
             binding.versionCheckText.text = getString(R.string.setting_using_latest_version)
         } else {
             binding.versionCheckText.text = getString(R.string.setting_need_update)


### PR DESCRIPTION
## 문제 원인
- 최신버전 체크는 SettingViewModel.versionCheck를 BuildConfig.VERSION_NAME과 비교하는 로직인데, LiveData인 versionCheck에 대한 observe가 누락되어있었다
  - -> 서버에서 GET /version/android 응답이 돌아오더라도 이미 onViewCreated 지난 시점이므로 문구가 "최신버전을 이용중입니다"로 갱신되지 않는다

## 변경사항
- 누락된 observe 복구