### PR TITLE
레스토랑 이름 길어질 때 오류 수정

### DIFF
--- a/app/src/main/res/drawable/ic_share.xml
+++ b/app/src/main/res/drawable/ic_share.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:tint="@color/orange_main"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    >
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+</vector>

--- a/app/src/main/res/layout/item_menu_group.xml
+++ b/app/src/main/res/layout/item_menu_group.xml
@@ -56,18 +56,17 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:layout_marginStart="9dp"
-                    android:layout_marginEnd="19dp"
                     android:src="@drawable/ic_star"
                     />
 
-<!--                <ImageView-->
-<!--                    android:id="@+id/share_button"-->
-<!--                    android:layout_width="16dp"-->
-<!--                    android:layout_height="16dp"-->
-<!--                    android:layout_marginStart="9dp"-->
-<!--                    android:layout_marginEnd="19dp"-->
-<!--                    android:src="@drawable/ic_share"-->
-<!--                    />-->
+                <ImageView
+                    android:id="@+id/share_button"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginStart="9dp"
+                    android:layout_marginEnd="19dp"
+                    android:src="@drawable/ic_share"
+                    />
 
             </TableRow>
 

--- a/app/src/main/res/layout/item_menu_group.xml
+++ b/app/src/main/res/layout/item_menu_group.xml
@@ -56,8 +56,16 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:layout_marginStart="9dp"
-                    android:layout_marginEnd="19dp"
                     android:src="@drawable/ic_star"
+                    />
+
+                <ImageView
+                    android:id="@+id/share_button"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginStart="9dp"
+                    android:layout_marginEnd="19dp"
+                    android:src="@drawable/ic_share"
                     />
 
             </TableRow>

--- a/app/src/main/res/layout/item_menu_group.xml
+++ b/app/src/main/res/layout/item_menu_group.xml
@@ -14,41 +14,55 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp">
 
-        <TextView
-            android:id="@+id/restaurant_title"
-            android:layout_width="wrap_content"
+        <TableLayout
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:fontFamily="@font/nanum_square_bold"
-            android:maxLines="1"
-            android:paddingVertical="10dp"
-            android:paddingStart="16dp"
-            android:textColor="@color/orange_main"
-            android:textSize="15dp"
+            android:shrinkColumns="0"
+            android:gravity="center_vertical"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="학생회관 식당" />
+            app:layout_constraintEnd_toStartOf="@id/price_info"
+            >
 
-        <ImageView
-            android:id="@+id/info_button"
-            android:layout_width="16dp"
-            android:layout_height="17dp"
-            android:layout_marginStart="10dp"
-            android:src="@drawable/ic_info"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/restaurant_title"
-            app:layout_constraintTop_toTopOf="parent" />
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center_vertical"
+                >
 
-        <ImageView
-            android:id="@+id/favorite_toggle"
-            android:layout_width="16dp"
-            android:layout_height="16dp"
-            android:layout_marginStart="10dp"
-            android:src="@drawable/ic_star"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toEndOf="@id/info_button"
-            app:layout_constraintTop_toTopOf="parent" />
+                <TextView
+                    android:id="@+id/restaurant_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/nanum_square_bold"
+                    android:singleLine="false"
+                    android:paddingVertical="10dp"
+                    android:paddingStart="16dp"
+                    android:textColor="@color/orange_main"
+                    android:textSize="15dp"
+                    tools:text="학생회관 식당" />
+
+                <ImageView
+                    android:id="@+id/info_button"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginStart="9dp"
+                    android:src="@drawable/ic_info"
+                    />
+
+                <ImageView
+                    android:id="@+id/favorite_toggle"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginStart="9dp"
+                    android:layout_marginEnd="19dp"
+                    android:src="@drawable/ic_star"
+                    />
+
+            </TableRow>
+
+        </TableLayout>
 
         <TextView
             android:id="@+id/price_info"

--- a/app/src/main/res/layout/item_menu_group.xml
+++ b/app/src/main/res/layout/item_menu_group.xml
@@ -56,17 +56,18 @@
                     android:layout_width="16dp"
                     android:layout_height="16dp"
                     android:layout_marginStart="9dp"
+                    android:layout_marginEnd="19dp"
                     android:src="@drawable/ic_star"
                     />
 
-                <ImageView
-                    android:id="@+id/share_button"
-                    android:layout_width="16dp"
-                    android:layout_height="16dp"
-                    android:layout_marginStart="9dp"
-                    android:layout_marginEnd="19dp"
-                    android:src="@drawable/ic_share"
-                    />
+<!--                <ImageView-->
+<!--                    android:id="@+id/share_button"-->
+<!--                    android:layout_width="16dp"-->
+<!--                    android:layout_height="16dp"-->
+<!--                    android:layout_marginStart="9dp"-->
+<!--                    android:layout_marginEnd="19dp"-->
+<!--                    android:src="@drawable/ic_share"-->
+<!--                    />-->
 
             </TableRow>
 


### PR DESCRIPTION
간만에 View로 뻘짓 좀 해서 남겨봅니다..

상황
<img width="266" alt="image" src="https://github.com/user-attachments/assets/f0aae678-d5ad-4d2c-8525-e50eb45a9027">
1. 여기서 restaurant_title이 짧을 경우 : info, star 버튼이 title 뒤에 바로 붙어야 함
2. restaurant_title이 길 경우 : info, star 버튼이 오른쪽에 고정되고 title은 아래로 줄바꿈이 되어야 함

뻘짓
1. 1번을 해결하기 위해 title의 width를 wrap_content로 함 -> title이 길어지면 뒤에 button들이 영역을 넘어서 없어져 버림
2. 이를 해결하기 위해 0dp로 함 -> title이 짧을 때도 나머지 영역을 다 차지하게 되어 info, star 버튼이 오른쪽에 고정됨
3. chatgpt 도움 받아서 뭐 weight 등 여러가지 방법 써봤는데 다 이상해짐
4. 구글링해본 결과, TableLayout 발견
(https://stackoverflow.com/questions/28824076/how-to-prevent-wrap-content-text-view-from-pushing-another-view-out-of-sight/28824186)
5. 해결~!

아직은 디테일한 문제는 chatgpt보다 구글링이 낫다,,