### PR TITLE
minSdk version 31로 올리기

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
 
     defaultConfig {
         applicationId = "com.wafflestudio.siksha2"
-        minSdk = 26
+        minSdk = 31
         targetSdk = 34
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
31에 도입된 GPS 관련 API를 활용하기 위해 버전 올림
이로 인해 사용할 수 없게 되는 기존 설치 사용자는 100명 정도 (Android 11 이하)